### PR TITLE
Update dependency "redis" to 4.2.1 version

### DIFF
--- a/lib/rejson/client.rb
+++ b/lib/rejson/client.rb
@@ -167,6 +167,6 @@ class Redis
 
   def call_client(cmd, pieces)
     pieces.prepend("JSON.#{cmd.upcase}").join(" ")
-    client.call pieces
+    @client.call pieces
   end
 end

--- a/lib/rejson/version.rb
+++ b/lib/rejson/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rejson
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/rejson-rb.gemspec
+++ b/rejson-rb.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "redis",        "~> 3.0"
+  spec.add_runtime_dependency "redis",        "~> 4.2.1"
   spec.add_runtime_dependency "json",         "~> 2.0"
   spec.add_development_dependency "bundler",  "~> 2.0"
   spec.add_development_dependency "rspec",    "~> 3.0"


### PR DESCRIPTION
Hi, @vachhanihpavan 
This update will allow using ```rejson-rb``` with other libraries, such as [redisearch-rb](https://github.com/vruizext/redisearch-rb) or [redi_search](https://github.com/npezza93/redi_search) and others as many of them depend on ```redis-rb``` v.4.0 and higher.
In my opinion, it will be very useful.

What do you think about ? 