### PR TITLE
Allow wider range of redis versions

### DIFF
--- a/rejson-rb.gemspec
+++ b/rejson-rb.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "json",          "~> 2.0"
-  spec.add_runtime_dependency "redis",         "~> 4.2.1"
+  spec.add_runtime_dependency "redis",         ">= 4.2.1", "< 5.0"
 
   spec.add_development_dependency "bundler",   "~> 2.0"
   spec.add_development_dependency "rspec",     "~> 3.0"


### PR DESCRIPTION
Not seeing anything obvious why this shouldn't work with newer versions and it's blocking updating other gems.